### PR TITLE
Fixes htmlentities call

### DIFF
--- a/rss.php
+++ b/rss.php
@@ -158,7 +158,7 @@ echo '
 	<item>
 		<pubDate>' . date("r") . '</pubDate>
 		<title>' . stripslashes($row['fullSeriesName']) . '</title>
-		<description><![CDATA[' . utf8_encode(htmlentities($row['description'],ENT_COMPAT,'utf-8')) . ']]></description>
+		<description><![CDATA[' . htmlentities($row['description'], ENT_COMPAT | ENT_SUBSTITUTE, 'utf-8') . ']]></description>
 		<guid isPermaLink="true">http://www.animeftw.tv/anime/' . $row['seoname'] . '/</guid>
 		<link>http://www.animeftw.tv/anime/' . $row['seoname'] . '/</link>
 		<author>support@animeftw.tv (AnimeFTW.tv Staff)</author>


### PR DESCRIPTION
When an invalid character is found, htmlentities returns an empty string by default. This fixes it to use a subtitute character instead (�), meaning that it will output the description, irrelevant of invalid character(s) or not present.

Why is the em-dash (—) considered invalid? Dunno.

Resolves #169 finally :P
